### PR TITLE
设置数据库的默认 engine 为 InnoDB, 防止数据库默认 engine 为 MyISAM 安装报 1071 错误

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -50,7 +50,7 @@ return [
             'collation' => 'utf8mb4_unicode_ci',
             'prefix' => env('DB_PREFIX', ''),
             'strict' => true,
-            'engine' => null,
+            'engine' => 'InnoDB',
         ],
 
         'pgsql' => [


### PR DESCRIPTION
设置数据库的默认 engine 为 InnoDB, 防止数据库默认 engine 为 MyISAM 安装报 1071 错误, 解决 ISSUE
#1 问题.